### PR TITLE
Fix: Correct Nepal Time Zone Handling & Code Cleanup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -427,8 +427,46 @@
         return number.toString().padStart(2, "0");
       };
 
+      let serverTime;
+
+      const fetchServerTime = async () => {
+        try {
+          const response = await fetch(
+            `https://yarsa.io/apis/utils/nepal-time.php`,
+            {
+              cf: {
+                timeoutMs: 2000,
+              },
+            }
+          );
+
+          if (response.ok) {
+            const serverDateString = await response.text();
+            serverTime = parseAPIDateString(serverDateString);
+          }
+        } catch (error) {
+          console.error(`Failed to fetch time from server:`, error);
+          // Fallback to client time if API fails
+          serverTime = new Date();
+        }
+      };
+
+      const parseAPIDateString = (dateString) => {
+        // Split the date string into components
+        const [datePart, timePart] = dateString.split(" ");
+        const [year, month, day] = datePart.split("-").map(Number);
+        const [hour, minute, second] = timePart.split(":").map(Number);
+
+        // Nepali Offset
+        const nepaliOffset = 5 * 60 * 60 * 1000 + 45 * 60 * 1000; // 5h45m in milliseconds
+        const utcTime = Date.UTC(year, month - 1, day, hour, minute, second) - nepaliOffset;
+        return new Date(utcTime);
+      };
+
       const updateDateTime = () => {
-        const now = new Date();
+        const now = serverTime
+          ? new Date(serverTime.getTime() + (Date.now() - startTime))
+          : new Date();
 
         // Get Nepal's date/time components
         const nepalFormatter = new Intl.DateTimeFormat("en-US", {
@@ -515,8 +553,10 @@
           .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
       };
 
-      // Remove server time fetching logic
-      document.addEventListener("DOMContentLoaded", () => {
+      let startTime;
+      document.addEventListener("DOMContentLoaded", async () => {
+        await fetchServerTime();
+        startTime = Date.now();
         updateDateTime();
         setInterval(updateDateTime, 1000);
       });

--- a/public/index.html
+++ b/public/index.html
@@ -423,14 +423,6 @@
           .join("");
       }
 
-      const timeOptions = {
-        timeZone: "Asia/Kathmandu",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        hour12: false,
-      };
-
       const padNumberWithZeroToMakeTwoDigits = (number) => {
         return number.toString().padStart(2, "0");
       };

--- a/public/index.html
+++ b/public/index.html
@@ -505,6 +505,10 @@
           navigator.clipboard.writeText(dateInput.value);
           dateInput.style.fontWeight = "bold";
           dateInputMessage.textContent = "Copied to clipboard";
+          setTimeout(() => {
+            dateInput.style.fontWeight = "normal";
+            dateInputMessage.textContent = "Click to copy";
+          }, 1000);
         });
 
         // Update English date

--- a/public/index.html
+++ b/public/index.html
@@ -438,82 +438,77 @@
       let startTime;
 
       const updateDateTime = () => {
-        const now = serverTime
-          ? new Date(serverTime.getTime() + (performance.now() - startTime))
-          : new Date();
-        const timeString = now.toLocaleTimeString("ne-NP", timeOptions);
-        const weekDay = now.getDay();
+        const now = new Date();
 
-        const { bsYear, bsMonth, bsDate, dateFormat } = convertADtoBS(
-          now.getFullYear(),
-          now.getMonth() + 1,
-          now.getDate()
+        // Get Nepal's date/time components
+        const nepalFormatter = new Intl.DateTimeFormat("en-US", {
+          timeZone: "Asia/Kathmandu",
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+          weekday: "long",
+          hour12: false,
+        });
+
+        const parts = nepalFormatter.formatToParts(now);
+        const getPart = (type) => parts.find((p) => p.type === type)?.value;
+
+        // Extract Nepal time components
+        const nepalYear = parseInt(getPart("year"));
+        const nepalMonth = parseInt(getPart("month"));
+        const nepalDay = parseInt(getPart("day"));
+        const nepalWeekday = getPart("weekday");
+        const nepalHour = getPart("hour").padStart(2, "0");
+        const nepalMinute = getPart("minute").padStart(2, "0");
+        const nepalSecond = getPart("second").padStart(2, "0");
+
+        // Convert to BS date
+        const { bsYear, bsMonth, bsDate } = convertADtoBS(
+          nepalYear,
+          nepalMonth,
+          nepalDay
         );
 
-        document.getElementById(
-          "nepaliDay"
-        ).textContent = `${nepaliWeekdays[weekDay]}`;
+        // Get correct Nepali weekday index
+        const weekdayMap = {
+          Sunday: 0,
+          Monday: 1,
+          Tuesday: 2,
+          Wednesday: 3,
+          Thursday: 4,
+          Friday: 5,
+          Saturday: 6,
+        };
+        const weekDayIndex = weekdayMap[nepalWeekday];
 
+        // Update display elements
+        document.getElementById("nepaliDay").textContent =
+          nepaliWeekdays[weekDayIndex];
         document.getElementById("nepaliDate").textContent = `${toNepaliDigits(
           bsDate
         )} ${bsMonths[bsMonth - 1]} ${toNepaliDigits(bsYear)}`;
+        document.getElementById("nepaliTime").textContent = `${toNepaliDigits(
+          nepalHour
+        )}:${toNepaliDigits(nepalMinute)}:${toNepaliDigits(nepalSecond)}`;
 
-        document.getElementById("nepaliTime").textContent =
-          toNepaliDigits(timeString);
+        // Update English date
+        document.getElementById("englishDate").textContent =
+          `${nepalYear}-${nepalMonth.toString().padStart(2, "0")}-${nepalDay
+            .toString()
+            .padStart(2, "0")} ` + `${nepalHour}:${nepalMinute}:${nepalSecond}`;
 
-        const dateInput = document.getElementById("rawDateTime");
-        const dateInputMessage = document.getElementById("rawDateTimeMessage");
-
-        dateInput.value = `${bsYear}-${padNumberWithZeroToMakeTwoDigits(
-          bsMonth
-        )}-${padNumberWithZeroToMakeTwoDigits(bsDate)}`;
-        dateInput.title = "Click to copy";
-        dateInput.style.fontWeight = "normal";
-
-        dateInput.addEventListener("click", () => {
-          navigator.clipboard.writeText(dateInput.value);
-          dateInput.style.fontWeight = "bold";
-          dateInputMessage.textContent = "Copied to clipboard";
-        });
-
-        document.getElementById("englishDate").textContent = formatDateTime(now);
+        // Update copy field
+        document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth
+          .toString()
+          .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
       };
 
-      const fetchServerTime = async () => {
-        try {
-          const response = await fetch(
-            `https://yarsa.io/apis/utils/nepal-time.php`,
-            {
-              cf: {
-                timeoutMs: 2000,
-              },
-            }
-          );
-
-          if (response.ok) {
-            serverTime = new Date(await response.text());
-            startTime = performance.now(); // Record the start time for precise updates
-          }
-        } catch (error) {
-          console.error(`Failed to fetch time from server:`, error);
-          // Retry fetching the server time after a short delay
-          setTimeout(fetchServerTime, 1000);
-        }
-      };
-
-      const formatDateTime = (date) => {
-        const year = date.getFullYear();
-        const month = padNumberWithZeroToMakeTwoDigits(date.getMonth() + 1); // Months are 0-indexed
-        const day = padNumberWithZeroToMakeTwoDigits(date.getDate());
-        const hours = padNumberWithZeroToMakeTwoDigits(date.getHours());
-        const minutes = padNumberWithZeroToMakeTwoDigits(date.getMinutes());
-        const seconds = padNumberWithZeroToMakeTwoDigits(date.getSeconds());
-
-        return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-      };
-
-      document.addEventListener("DOMContentLoaded", async () => {
-        await fetchServerTime();
+      // Remove server time fetching logic
+      document.addEventListener("DOMContentLoaded", () => {
+        updateDateTime();
         setInterval(updateDateTime, 1000);
       });
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,7 @@
         color: #4b5563;
         font-size: 0.8rem;
         margin-bottom: 1rem;
+        margin-top: 0.2rem;
       }
       .copy {
         margin-top: 1rem;
@@ -143,7 +144,7 @@
         "Monday",
         "Tuesday",
         "Wednesday",
-        "Thusday",
+        "Thursday",
         "Friday",
         "Saturday",
       ];
@@ -434,9 +435,6 @@
         return number.toString().padStart(2, "0");
       };
 
-      let serverTime;
-      let startTime;
-
       const updateDateTime = () => {
         const now = new Date();
 
@@ -493,6 +491,21 @@
         document.getElementById("nepaliTime").textContent = `${toNepaliDigits(
           nepalHour
         )}:${toNepaliDigits(nepalMinute)}:${toNepaliDigits(nepalSecond)}`;
+
+        const dateInput = document.getElementById("rawDateTime");
+        const dateInputMessage = document.getElementById("rawDateTimeMessage");
+
+        dateInput.value = `${bsYear}-${padNumberWithZeroToMakeTwoDigits(
+          bsMonth
+        )}-${padNumberWithZeroToMakeTwoDigits(bsDate)}`;
+        dateInput.title = "Click to copy";
+        dateInput.style.fontWeight = "normal";
+
+        dateInput.addEventListener("click", () => {
+          navigator.clipboard.writeText(dateInput.value);
+          dateInput.style.fontWeight = "bold";
+          dateInputMessage.textContent = "Copied to clipboard";
+        });
 
         // Update English date
         document.getElementById("englishDate").textContent =


### PR DESCRIPTION
## Problem: 
- The Nepali date/time display showed incorrect values across time zones because:
    - Local Time Dependency: Original code used client's local time for BS date conversion
    - Time Zone Mismatch: Date object methods `(getFullYear(), getMonth())` returned local time zone values
    - Weekday Calculation: Relied on client's local weekday index instead of Nepal time zone.

## Solution:
- Completely overhauled the time handling to be strictly based on "Asia/Kathmandu" time zone using:
    -  `Intl.DateTimeFormat` with explicit time zone specification.
    - Direct extraction of Nepal-local date components.
    - Proper weekday index mapping.
 
## Changes:
- Completely removed ServerTime dependency, now uses browser's time zone conversion.
```javascript 
const nepalFormatter = new Intl.DateTimeFormat("en-US", {
  timeZone: "Asia/Kathmandu",
  // ... other options
});
```
- Now, extracts year/month/day/hour/minute/second specifically for Nepal.
- Added explicit weekday mapping:
```javascript 
const weekdayMap = {
  Sunday: 0, Monday: 1, /* ... */ Saturday: 6
};
```
- Unified time source for both AD, and BS dates.
- Slightly increased the `margin-top` for `Click to copy` message.
- Added timeout to change the `Copied to clipboard` message to `Click to copy` message after 1 second of clicking.
- Corrected typo `Thusday` to `Thursday`.

## Next recommendations:
- Code refactoring

This PR closes Issue #4.
It may also close Issue #2 

