### PR TITLE
fix: ues system date until server responds. closes #2

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -555,6 +555,7 @@
 
       let startTime;
       document.addEventListener("DOMContentLoaded", async () => {
+        updateDateTime();
         await fetchServerTime();
         startTime = Date.now();
         updateDateTime();


### PR DESCRIPTION
With this commit, user won't most likely see a loading screen. I tried to mention this in my PR review of https://github.com/yarsa/nepalidate.org/pull/6 but it looks like the PR got merged without actually making the suggesting changes. Hence this PR.