### PR TITLE
 Improve English Date Format Display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -571,10 +571,18 @@
       });
 
       // Update English date
+      const englishMonths = [
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December'
+      ];
+
+      // Convert 24-hour format to 12-hour format with AM/PM
+      const hour12 = nepalHour % 12 || 12;
+      const ampm = nepalHour >= 12 ? 'PM' : 'AM';
+
       document.getElementById("englishDate").textContent =
-        `${nepalYear}-${nepalMonth.toString().padStart(2, "0")}-${nepalDay
-          .toString()
-          .padStart(2, "0")} ` + `${nepalHour}:${nepalMinute}:${nepalSecond}`;
+        `${nepalDay} ${englishMonths[nepalMonth - 1]} ${nepalYear} ${hour12}:${nepalMinute}${ampm}`;
+
 
       // Update copy field
       document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth

--- a/public/index.html
+++ b/public/index.html
@@ -1,592 +1,596 @@
 <!DOCTYPE html>
 <html lang="ne">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Today's Nepali Date and Time | आजको नेपाली मिति र समय</title>
-    <style>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Today's Nepali Date and Time | आजको नेपाली मिति र समय</title>
+  <style>
+    :root {
+      --bgPrimary: #f3f9fc;
+      --bgSecondary: white;
+      --bgTertiary: #f3f4f6;
+      --bgExtra: #f9f9f9;
+      --fontPrimary: #374151;
+      --fontSecondary: #4b5563;
+      --fontTertiary: #1f2937;
+      --borderPrimary: #e5e7eb;
+      --borderSecondary: #d1d5db;
+    }
+
+    @media (prefers-color-scheme: dark) {
       :root {
-        --bgPrimary: #f3f9fc;
-        --bgSecondary: white;
-        --bgTertiary: #f3f4f6;
-        --bgExtra: #f9f9f9;
-        --fontPrimary: #374151;
-        --fontSecondary: #4b5563;
+        --bgPrimary: black;
+        --bgSecondary: grey;
+        --bgTertiary: black;
+        --bgExtra: #888;
+        --fontPrimary: white;
+        --fontSecondary: white;
         --fontTertiary: #1f2937;
-        --borderPrimary: #e5e7eb;
-        --borderSecondary: #d1d5db;
+        --borderPrimary: #0e0e0e;
+        --borderSecondary: #222;
       }
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bgPrimary: black;
-          --bgSecondary: grey;
-          --bgTertiary: black;
-          --bgExtra: #888;
-          --fontPrimary: white;
-          --fontSecondary: white;
-          --fontTertiary: #1f2937;
-          --borderPrimary: #0e0e0e;
-          --borderSecondary: #222;
-        }
-      }
-      body {
-        margin: 0;
-        padding: 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        min-height: 100vh;
-        background-color: var(--bgPrimary);
-        font-family: "Noto Sans Devanagari", sans-serif;
-      }
+    }
 
-      .container {
-        background-color: var(--bgSecondary);
-        border-radius: 1rem;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        text-align: center;
-        width: 80%;
-        max-width: 720px;
-        padding-top: 4rem;
-        border: 1px solid var(--borderPrimary);
-      }
-      .wrapper {
-        padding: 1rem;
-      }
-      .day {
-        font-size: 3rem;
-        font-weight: bold;
-        color: var(--fontPrimary);
-        margin-bottom: 1rem;
-        text-align: center;
-      }
-      .date {
-        font-size: 5rem;
-        font-weight: bold;
-        color: var(--fontTertiary);
-        margin-bottom: 1rem;
-        text-align: center;
-      }
+    body {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      background-color: var(--bgPrimary);
+      font-family: "Noto Sans Devanagari", sans-serif;
+    }
 
-      .time {
-        font-size: 2rem;
-        color: var(--fontSecondary);
-      }
+    .container {
+      background-color: var(--bgSecondary);
+      border-radius: 1rem;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+      text-align: center;
+      width: 80%;
+      max-width: 720px;
+      padding-top: 4rem;
+      border: 1px solid var(--borderPrimary);
+    }
 
-      .copyMessage {
-        color: var(--fontSecondary);
-        font-size: 0.8rem;
-        margin-bottom: 1rem;
-        margin-top: 0.2rem;
-      }
-      .copy {
-        margin-top: 1rem;
-        cursor: pointer;
-        background-color: var(--bgExtra);
-        border: 1px solid var(--borderSecondary);
-        color: var(--fontSecondary);
-        border-radius: 0.5rem;
-        padding: 0.5rem 1rem;
-        font-size: 1.2rem;
-        text-align: center;
-        font-weight: bold;
-      }
-      .footer {
-        margin-top: 2rem;
-        padding: 1rem;
-        background-color: var(--bgTertiary);
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-        font-size: 1rem;
-        color: var(--fontSecondary);
-        gap: 1rem;
-      }
-      .footer a {
-        text-decoration: none;
-        color: var(--fontSecondary);
-        font-weight: bold;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="wrapper">
-        <div class="day" id="nepaliDay"></div>
-        <div class="date" id="nepaliDate"></div>
-        <div style="width: 14ch; margin: auto; text-align: left">
-          <div class="time" id="nepaliTime"></div>
-        </div>
-      </div>
+    .wrapper {
+      padding: 1rem;
+    }
 
-      <div class="footer">
-        <span id="englishDate"></span>
-        &middot;
-        <span id="footertext">
-          <a href="https://github.com/yarsa/nepalidate.org">Source Code</a>
-        </span>
-      </div>
-      <div>
-        <input
-          title="Click to copy"
-          class="copy"
-          id="rawDateTime"
-          readonly
-          size="10"
-        />
-        <div class="copyMessage" id="rawDateTimeMessage">Click to copy</div>
+    .day {
+      font-size: 3rem;
+      font-weight: bold;
+      color: var(--fontPrimary);
+      margin-bottom: 1rem;
+      text-align: center;
+    }
+
+    .date {
+      font-size: 5rem;
+      font-weight: bold;
+      color: var(--fontTertiary);
+      margin-bottom: 1rem;
+      text-align: center;
+    }
+
+    .time {
+      font-size: 2rem;
+      color: var(--fontSecondary);
+    }
+
+    .copyMessage {
+      color: var(--fontSecondary);
+      font-size: 0.8rem;
+      margin-bottom: 1rem;
+      margin-top: 0.2rem;
+    }
+
+    .copy {
+      margin-top: 1rem;
+      cursor: pointer;
+      background-color: var(--bgExtra);
+      border: 1px solid var(--borderSecondary);
+      color: var(--fontSecondary);
+      border-radius: 0.5rem;
+      padding: 0.5rem 1rem;
+      font-size: 1.2rem;
+      text-align: center;
+      font-weight: bold;
+    }
+
+    .footer {
+      margin-top: 2rem;
+      padding: 1rem;
+      background-color: var(--bgTertiary);
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      font-size: 1rem;
+      color: var(--fontSecondary);
+      gap: 1rem;
+    }
+
+    .footer a {
+      text-decoration: none;
+      color: var(--fontSecondary);
+      font-weight: bold;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <div class="wrapper">
+      <div class="day" id="nepaliDay"></div>
+      <div class="date" id="nepaliDate"></div>
+      <div style="width: 14ch; margin: auto; text-align: left">
+        <div class="time" id="nepaliTime"></div>
       </div>
     </div>
 
-    <script>
-      const bsMonths = [
-        "बैशाख",
-        "जेठ",
-        "आषाढ",
-        "श्रावण",
-        "भदौ",
-        "असोज",
-        "कार्तिक",
-        "मंसिर",
-        "पौष",
-        "माघ",
-        "फाल्गुन",
-        "चैत्र",
-      ];
-      const bsDays = ["आईत", "सोम", "मंगल", "बुध", "बिही", "शुक्र", "शनि"];
-      const bsDaysFull = [
-        "आइतवार",
-        "सोमवार",
-        "मंगलवार",
-        "बुधवार",
-        "बिहिवार",
-        "शुक्रवार",
-        "शनिवार",
-      ];
-      const adDays = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-      const adDaysFull = [
-        "Sunday",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-      ];
-      const nepaliNumbers = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
-      const bsMonthUpperDays = [
-        [30, 31],
-        [31, 32],
-        [31, 32],
-        [31, 32],
-        [31, 32],
-        [30, 31],
-        [29, 30],
-        [29, 30],
-        [29, 30],
-        [29, 30],
-        [29, 30],
-        [30, 31],
-      ];
-      const extractedBsMonthData = [
-        [
-          0, 1, 1, 22, 1, 3, 1, 1, 1, 3, 1, 22, 1, 3, 1, 3, 1, 22, 1, 3, 1, 19,
-          1, 3, 1, 1, 3, 1, 2, 2, 1, 3, 1,
-        ],
-        [
-          1, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 3, 2, 2, 2, 1, 3, 1, 3,
-          1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2,
-          2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 1, 1, 1, 2, 2, 2, 2, 2, 1, 3, 1, 1,
-          2,
-        ],
-        [
-          0, 1, 2, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2,
-          2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2,
-          2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 1, 1, 1, 2, 2, 2, 2, 2, 1, 3, 1,
-          1, 2,
-        ],
-        [
-          1, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1,
-          3, 1, 3, 1, 3, 1, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2,
-          1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 2, 2, 1, 3, 1, 2, 2, 2, 1, 2,
-        ],
-        [59, 1, 26, 1, 28, 1, 2, 1, 12],
-        [
-          0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2,
-          2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1,
-          3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 5, 1, 1, 2, 2, 1, 3, 1, 2, 1, 2,
-        ],
-        [
-          0, 12, 1, 3, 1, 3, 1, 5, 1, 11, 1, 3, 1, 3, 1, 18, 1, 3, 1, 3, 1, 18,
-          1, 3, 1, 3, 1, 27, 1, 2,
-        ],
-        [
-          1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 3, 1, 3, 2, 2, 2, 2, 2, 2, 2,
-          2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2,
-          2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 15, 2, 4,
-        ],
-        [
-          0, 1, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 3, 2, 2, 2, 1, 3, 1,
-          3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2,
-          2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 15, 2, 4,
-        ],
-        [
-          1, 1, 3, 1, 3, 1, 14, 1, 3, 1, 1, 1, 3, 1, 14, 1, 3, 1, 3, 1, 3, 1,
-          18, 1, 3, 1, 3, 1, 3, 1, 14, 1, 3, 15, 1, 2, 1, 1,
-        ],
-        [
-          0, 1, 1, 3, 1, 3, 1, 10, 1, 3, 1, 3, 1, 1, 1, 3, 1, 3, 1, 10, 1, 3, 1,
-          3, 1, 3, 1, 3, 1, 14, 1, 3, 1, 3, 1, 3, 1, 3, 1, 10, 1, 20, 1, 1, 1,
-        ],
-        [
-          1, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 1, 3,
-          1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 2, 2,
-          2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 20, 3,
-        ],
-      ];
-      const minBsYear = 1970;
-      const maxBsYear = 2100;
-      const minAdDateEqBsDate = {
-        ad: {
-          year: 1913,
-          month: 3,
-          date: 13,
-        },
-        bs: {
-          year: 1970,
-          month: 1,
-          date: 1,
-        },
-      };
+    <div class="footer">
+      <span id="englishDate"></span>
+      &middot;
+      <span id="footertext">
+        <a href="https://github.com/yarsa/nepalidate.org">Source Code</a>
+      </span>
+    </div>
+    <div>
+      <input title="Click to copy" class="copy" id="rawDateTime" readonly size="10" />
+      <div class="copyMessage" id="rawDateTimeMessage">Click to copy</div>
+    </div>
+  </div>
 
-      const toDevanagariDigits = (number) => {
-        return String(number)
-          .split("")
-          .map((ed) => nepaliNumbers[Number(ed)])
-          .join("");
-      };
+  <script>
+    const bsMonths = [
+      "बैशाख",
+      "जेठ",
+      "आषाढ",
+      "श्रावण",
+      "भदौ",
+      "असोज",
+      "कार्तिक",
+      "मंसिर",
+      "पौष",
+      "माघ",
+      "फाल्गुन",
+      "चैत्र",
+    ];
+    const bsDays = ["आईत", "सोम", "मंगल", "बुध", "बिही", "शुक्र", "शनि"];
+    const bsDaysFull = [
+      "आइतवार",
+      "सोमवार",
+      "मंगलवार",
+      "बुधवार",
+      "बिहिवार",
+      "शुक्रवार",
+      "शनिवार",
+    ];
+    const adDays = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    const adDaysFull = [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ];
+    const nepaliNumbers = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"];
+    const bsMonthUpperDays = [
+      [30, 31],
+      [31, 32],
+      [31, 32],
+      [31, 32],
+      [31, 32],
+      [30, 31],
+      [29, 30],
+      [29, 30],
+      [29, 30],
+      [29, 30],
+      [29, 30],
+      [30, 31],
+    ];
+    const extractedBsMonthData = [
+      [
+        0, 1, 1, 22, 1, 3, 1, 1, 1, 3, 1, 22, 1, 3, 1, 3, 1, 22, 1, 3, 1, 19,
+        1, 3, 1, 1, 3, 1, 2, 2, 1, 3, 1,
+      ],
+      [
+        1, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 3, 2, 2, 2, 1, 3, 1, 3,
+        1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 1, 1, 1, 2, 2, 2, 2, 2, 1, 3, 1, 1,
+        2,
+      ],
+      [
+        0, 1, 2, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2,
+        2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 1, 1, 1, 2, 2, 2, 2, 2, 1, 3, 1,
+        1, 2,
+      ],
+      [
+        1, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1,
+        3, 1, 3, 1, 3, 1, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2,
+        1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 2, 2, 1, 3, 1, 2, 2, 2, 1, 2,
+      ],
+      [59, 1, 26, 1, 28, 1, 2, 1, 12],
+      [
+        0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1,
+        3, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 5, 1, 1, 2, 2, 1, 3, 1, 2, 1, 2,
+      ],
+      [
+        0, 12, 1, 3, 1, 3, 1, 5, 1, 11, 1, 3, 1, 3, 1, 18, 1, 3, 1, 3, 1, 18,
+        1, 3, 1, 3, 1, 27, 1, 2,
+      ],
+      [
+        1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 3, 1, 3, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 15, 2, 4,
+      ],
+      [
+        0, 1, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 3, 2, 2, 2, 1, 3, 1,
+        3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 1, 3, 1, 3, 1, 2, 2, 2, 15, 2, 4,
+      ],
+      [
+        1, 1, 3, 1, 3, 1, 14, 1, 3, 1, 1, 1, 3, 1, 14, 1, 3, 1, 3, 1, 3, 1,
+        18, 1, 3, 1, 3, 1, 3, 1, 14, 1, 3, 15, 1, 2, 1, 1,
+      ],
+      [
+        0, 1, 1, 3, 1, 3, 1, 10, 1, 3, 1, 3, 1, 1, 1, 3, 1, 3, 1, 10, 1, 3, 1,
+        3, 1, 3, 1, 3, 1, 14, 1, 3, 1, 3, 1, 3, 1, 3, 1, 10, 1, 20, 1, 1, 1,
+      ],
+      [
+        1, 2, 2, 1, 3, 1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 1, 3,
+        1, 3, 1, 3, 1, 2, 2, 2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 3, 1, 3, 1, 2, 2,
+        2, 2, 2, 2, 2, 1, 3, 1, 3, 1, 20, 3,
+      ],
+    ];
+    const minBsYear = 1970;
+    const maxBsYear = 2100;
+    const minAdDateEqBsDate = {
+      ad: {
+        year: 1913,
+        month: 3,
+        date: 13,
+      },
+      bs: {
+        year: 1970,
+        month: 1,
+        date: 1,
+      },
+    };
 
-      const getTotalDaysNumFromMinBsYear = (bsYear, bsMonth, bsDate) => {
-        if (bsYear < minBsYear || bsYear > maxBsYear) {
-          return null;
-        }
+    const toDevanagariDigits = (number) => {
+      return String(number)
+        .split("")
+        .map((ed) => nepaliNumbers[Number(ed)])
+        .join("");
+    };
 
-        let daysNumFromMinBsYear = 0;
-        const diffYears = bsYear - minBsYear;
-        for (let month = 1; month <= 12; month++) {
-          if (month < bsMonth) {
-            daysNumFromMinBsYear += getMonthDaysNumFormMinBsYear(
-              month,
-              diffYears + 1
-            );
-          } else {
-            daysNumFromMinBsYear += getMonthDaysNumFormMinBsYear(
-              month,
-              diffYears
-            );
-          }
-        }
-
-        if (bsYear > 2085 && bsYear < 2088) {
-          daysNumFromMinBsYear += bsDate - 2;
-        } else if (bsYear === 2085 && bsMonth > 5) {
-          daysNumFromMinBsYear += bsDate - 2;
-        } else if (bsYear > 2088) {
-          daysNumFromMinBsYear += bsDate - 4;
-        } else if (bsYear === 2088 && bsMonth > 5) {
-          daysNumFromMinBsYear += bsDate - 4;
-        } else {
-          daysNumFromMinBsYear += bsDate;
-        }
-
-        return daysNumFromMinBsYear;
-      };
-
-      const getMonthDaysNumFormMinBsYear = (bsMonth, yearDiff) => {
-        let yearCount = 0;
-        let monthDaysFromMinBsYear = 0;
-        if (yearDiff === 0) return 0;
-
-        const bsMonthData = extractedBsMonthData[bsMonth - 1];
-        for (let i = 0; i < bsMonthData.length; i++) {
-          if (bsMonthData[i] === 0) {
-            continue;
-          }
-          const bsMonthUpperDaysIndex = i % 2;
-          if (yearDiff > yearCount + bsMonthData[i]) {
-            yearCount += bsMonthData[i];
-            monthDaysFromMinBsYear +=
-              bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] *
-              bsMonthData[i];
-          } else {
-            monthDaysFromMinBsYear +=
-              bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] *
-              (yearDiff - yearCount);
-            yearCount = yearDiff - yearCount;
-            break;
-          }
-        }
-
-        return monthDaysFromMinBsYear;
-      };
-
-      const getBsMonthDays = (bsYear, bsMonth) => {
-        let yearCount = 0;
-        if (bsYear === null || bsMonth === null) {
-          return null;
-        }
-        const totalYears = bsYear + 1 - minBsYear;
-        const bsMonthData = extractedBsMonthData[bsMonth - 1];
-        for (let i = 0; i < bsMonthData.length; i++) {
-          if (bsMonthData[i] === 0) {
-            continue;
-          }
-
-          const bsMonthUpperDaysIndex = i % 2;
-          yearCount += bsMonthData[i];
-          if (totalYears <= yearCount) {
-            if (
-              (bsYear === 2085 && bsMonth === 5) ||
-              (bsYear === 2088 && bsMonth === 5)
-            ) {
-              return bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] - 2;
-            } else {
-              return bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex];
-            }
-          }
-        }
-
+    const getTotalDaysNumFromMinBsYear = (bsYear, bsMonth, bsDate) => {
+      if (bsYear < minBsYear || bsYear > maxBsYear) {
         return null;
-      };
-
-      const convertADtoBS = (adYear, adMonth, adDate) => {
-        let bsYear = adYear + 57;
-        let bsMonth = (adMonth + 9) % 12;
-        bsMonth = bsMonth === 0 ? 12 : bsMonth;
-        let bsDate = 1;
-
-        if (adMonth < 4) {
-          bsYear -= 1;
-        }
-
-        const bsMonthFirstAdDate = convertBStoAD(bsYear, bsMonth, 1);
-        if (adDate >= 1 && adDate < bsMonthFirstAdDate.getDate()) {
-          if (adMonth === 4) {
-            const bsYearFirstAdDate = convertBStoAD(bsYear, 1, 1);
-            if (adDate < bsYearFirstAdDate.getDate()) {
-              bsYear -= 1;
-            }
-          }
-          bsMonth = bsMonth !== 1 ? bsMonth - 1 : 12;
-          const bsMonthDays = getBsMonthDays(bsYear, bsMonth);
-          if (bsMonthDays !== null) {
-            bsDate = bsMonthDays - (bsMonthFirstAdDate.getDate() - adDate) + 1;
-          }
-        } else {
-          bsDate = adDate - bsMonthFirstAdDate.getDate() + 1;
-        }
-        const dateFormat = `${toDevanagariDigits(bsYear)} ${
-          bsMonths[bsMonth - 1]
-        } ${toDevanagariDigits(bsDate)}`;
-        return { bsYear, bsMonth, bsDate, dateFormat };
-      };
-
-      const convertBStoAD = (bsYear, bsMonth, bsDate) => {
-        if (bsYear === null || bsMonth === null || bsDate === null) {
-          return new Date();
-        }
-
-        const daysNumFromMinBsYear = getTotalDaysNumFromMinBsYear(
-          bsYear,
-          bsMonth,
-          bsDate
-        );
-        const adDate = new Date(
-          minAdDateEqBsDate.ad.year,
-          minAdDateEqBsDate.ad.month,
-          minAdDateEqBsDate.ad.date - 1
-        );
-        if (daysNumFromMinBsYear !== null) {
-          adDate.setDate(adDate.getDate() + daysNumFromMinBsYear);
-        }
-        return adDate;
-      };
-
-      // Nepali weekdays
-      const nepaliWeekdays = [
-        "आइतबार",
-        "सोमबार",
-        "मंगलबार",
-        "बुधबार",
-        "बिहिबार",
-        "शुक्रबार",
-        "शनिबार",
-      ];
-
-      // Nepali months
-      const nepaliMonths = [
-        "बैशाख",
-        "जेठ",
-        "असार",
-        "श्रावण",
-        "भदौ",
-        "असोज",
-        "कार्तिक",
-        "मंसिर",
-        "पुष",
-        "माघ",
-        "फागुन",
-        "चैत",
-      ];
-
-      // Convert to Nepali digits
-      function toNepaliDigits(number) {
-        return number
-          .toString()
-          .split("")
-          .map((digit) => nepaliNumbers[digit] || digit)
-          .join("");
       }
 
-      const padNumberWithZeroToMakeTwoDigits = (number) => {
-        return number.toString().padStart(2, "0");
-      };
-
-      let serverTime;
-
-      const fetchServerTime = async () => {
-        try {
-          const response = await fetch(
-            `https://yarsa.io/apis/utils/nepal-time.php`,
-            {
-              cf: {
-                timeoutMs: 2000,
-              },
-            }
+      let daysNumFromMinBsYear = 0;
+      const diffYears = bsYear - minBsYear;
+      for (let month = 1; month <= 12; month++) {
+        if (month < bsMonth) {
+          daysNumFromMinBsYear += getMonthDaysNumFormMinBsYear(
+            month,
+            diffYears + 1
           );
-
-          if (response.ok) {
-            const serverDateString = await response.text();
-            serverTime = parseAPIDateString(serverDateString);
-          }
-        } catch (error) {
-          console.error(`Failed to fetch time from server:`, error);
-          // Fallback to client time if API fails
-          serverTime = new Date();
+        } else {
+          daysNumFromMinBsYear += getMonthDaysNumFormMinBsYear(
+            month,
+            diffYears
+          );
         }
-      };
+      }
 
-      const parseAPIDateString = (dateString) => {
-        // Split the date string into components
-        const [datePart, timePart] = dateString.split(" ");
-        const [year, month, day] = datePart.split("-").map(Number);
-        const [hour, minute, second] = timePart.split(":").map(Number);
+      if (bsYear > 2085 && bsYear < 2088) {
+        daysNumFromMinBsYear += bsDate - 2;
+      } else if (bsYear === 2085 && bsMonth > 5) {
+        daysNumFromMinBsYear += bsDate - 2;
+      } else if (bsYear > 2088) {
+        daysNumFromMinBsYear += bsDate - 4;
+      } else if (bsYear === 2088 && bsMonth > 5) {
+        daysNumFromMinBsYear += bsDate - 4;
+      } else {
+        daysNumFromMinBsYear += bsDate;
+      }
 
-        // Nepali Offset
-        const nepaliOffset = 5 * 60 * 60 * 1000 + 45 * 60 * 1000; // 5h45m in milliseconds
-        const utcTime = Date.UTC(year, month - 1, day, hour, minute, second) - nepaliOffset;
-        return new Date(utcTime);
-      };
+      return daysNumFromMinBsYear;
+    };
 
-      const updateDateTime = () => {
-        const now = serverTime
-          ? new Date(serverTime.getTime() + (Date.now() - startTime))
-          : new Date();
+    const getMonthDaysNumFormMinBsYear = (bsMonth, yearDiff) => {
+      let yearCount = 0;
+      let monthDaysFromMinBsYear = 0;
+      if (yearDiff === 0) return 0;
 
-        // Get Nepal's date/time components
-        const nepalFormatter = new Intl.DateTimeFormat("en-US", {
-          timeZone: "Asia/Kathmandu",
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric",
-          weekday: "long",
-          hour12: false,
-        });
+      const bsMonthData = extractedBsMonthData[bsMonth - 1];
+      for (let i = 0; i < bsMonthData.length; i++) {
+        if (bsMonthData[i] === 0) {
+          continue;
+        }
+        const bsMonthUpperDaysIndex = i % 2;
+        if (yearDiff > yearCount + bsMonthData[i]) {
+          yearCount += bsMonthData[i];
+          monthDaysFromMinBsYear +=
+            bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] *
+            bsMonthData[i];
+        } else {
+          monthDaysFromMinBsYear +=
+            bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] *
+            (yearDiff - yearCount);
+          yearCount = yearDiff - yearCount;
+          break;
+        }
+      }
 
-        const parts = nepalFormatter.formatToParts(now);
-        const getPart = (type) => parts.find((p) => p.type === type)?.value;
+      return monthDaysFromMinBsYear;
+    };
 
-        // Extract Nepal time components
-        const nepalYear = parseInt(getPart("year"));
-        const nepalMonth = parseInt(getPart("month"));
-        const nepalDay = parseInt(getPart("day"));
-        const nepalWeekday = getPart("weekday");
-        const nepalHour = getPart("hour").padStart(2, "0");
-        const nepalMinute = getPart("minute").padStart(2, "0");
-        const nepalSecond = getPart("second").padStart(2, "0");
+    const getBsMonthDays = (bsYear, bsMonth) => {
+      let yearCount = 0;
+      if (bsYear === null || bsMonth === null) {
+        return null;
+      }
+      const totalYears = bsYear + 1 - minBsYear;
+      const bsMonthData = extractedBsMonthData[bsMonth - 1];
+      for (let i = 0; i < bsMonthData.length; i++) {
+        if (bsMonthData[i] === 0) {
+          continue;
+        }
 
-        // Convert to BS date
-        const { bsYear, bsMonth, bsDate } = convertADtoBS(
-          nepalYear,
-          nepalMonth,
-          nepalDay
+        const bsMonthUpperDaysIndex = i % 2;
+        yearCount += bsMonthData[i];
+        if (totalYears <= yearCount) {
+          if (
+            (bsYear === 2085 && bsMonth === 5) ||
+            (bsYear === 2088 && bsMonth === 5)
+          ) {
+            return bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex] - 2;
+          } else {
+            return bsMonthUpperDays[bsMonth - 1][bsMonthUpperDaysIndex];
+          }
+        }
+      }
+
+      return null;
+    };
+
+    const convertADtoBS = (adYear, adMonth, adDate) => {
+      let bsYear = adYear + 57;
+      let bsMonth = (adMonth + 9) % 12;
+      bsMonth = bsMonth === 0 ? 12 : bsMonth;
+      let bsDate = 1;
+
+      if (adMonth < 4) {
+        bsYear -= 1;
+      }
+
+      const bsMonthFirstAdDate = convertBStoAD(bsYear, bsMonth, 1);
+      if (adDate >= 1 && adDate < bsMonthFirstAdDate.getDate()) {
+        if (adMonth === 4) {
+          const bsYearFirstAdDate = convertBStoAD(bsYear, 1, 1);
+          if (adDate < bsYearFirstAdDate.getDate()) {
+            bsYear -= 1;
+          }
+        }
+        bsMonth = bsMonth !== 1 ? bsMonth - 1 : 12;
+        const bsMonthDays = getBsMonthDays(bsYear, bsMonth);
+        if (bsMonthDays !== null) {
+          bsDate = bsMonthDays - (bsMonthFirstAdDate.getDate() - adDate) + 1;
+        }
+      } else {
+        bsDate = adDate - bsMonthFirstAdDate.getDate() + 1;
+      }
+      const dateFormat = `${toDevanagariDigits(bsYear)} ${bsMonths[bsMonth - 1]
+        } ${toDevanagariDigits(bsDate)}`;
+      return { bsYear, bsMonth, bsDate, dateFormat };
+    };
+
+    const convertBStoAD = (bsYear, bsMonth, bsDate) => {
+      if (bsYear === null || bsMonth === null || bsDate === null) {
+        return new Date();
+      }
+
+      const daysNumFromMinBsYear = getTotalDaysNumFromMinBsYear(
+        bsYear,
+        bsMonth,
+        bsDate
+      );
+      const adDate = new Date(
+        minAdDateEqBsDate.ad.year,
+        minAdDateEqBsDate.ad.month,
+        minAdDateEqBsDate.ad.date - 1
+      );
+      if (daysNumFromMinBsYear !== null) {
+        adDate.setDate(adDate.getDate() + daysNumFromMinBsYear);
+      }
+      return adDate;
+    };
+
+    // Nepali weekdays
+    const nepaliWeekdays = [
+      "आइतबार",
+      "सोमबार",
+      "मंगलबार",
+      "बुधबार",
+      "बिहिबार",
+      "शुक्रबार",
+      "शनिबार",
+    ];
+
+    // Nepali months
+    const nepaliMonths = [
+      "बैशाख",
+      "जेठ",
+      "असार",
+      "श्रावण",
+      "भदौ",
+      "असोज",
+      "कार्तिक",
+      "मंसिर",
+      "पुष",
+      "माघ",
+      "फागुन",
+      "चैत",
+    ];
+
+    // Convert to Nepali digits
+    function toNepaliDigits(number) {
+      return number
+        .toString()
+        .split("")
+        .map((digit) => nepaliNumbers[digit] || digit)
+        .join("");
+    }
+
+    const padNumberWithZeroToMakeTwoDigits = (number) => {
+      return number.toString().padStart(2, "0");
+    };
+
+    let serverTime;
+
+    const fetchServerTime = async () => {
+      try {
+        const response = await fetch(
+          `https://yarsa.io/apis/utils/nepal-time.php`,
+          {
+            cf: {
+              timeoutMs: 2000,
+            },
+          }
         );
 
-        // Get correct Nepali weekday index
-        const weekdayMap = {
-          Sunday: 0,
-          Monday: 1,
-          Tuesday: 2,
-          Wednesday: 3,
-          Thursday: 4,
-          Friday: 5,
-          Saturday: 6,
-        };
-        const weekDayIndex = weekdayMap[nepalWeekday];
+        if (response.ok) {
+          const serverDateString = await response.text();
+          serverTime = parseAPIDateString(serverDateString);
+        }
+      } catch (error) {
+        console.error(`Failed to fetch time from server:`, error);
+        // Fallback to client time if API fails
+        serverTime = new Date();
+      }
+    };
 
-        // Update display elements
-        document.getElementById("nepaliDay").textContent =
-          nepaliWeekdays[weekDayIndex];
-        document.getElementById("nepaliDate").textContent = `${toNepaliDigits(
-          bsDate
-        )} ${bsMonths[bsMonth - 1]} ${toNepaliDigits(bsYear)}`;
-        document.getElementById("nepaliTime").textContent = `${toNepaliDigits(
-          nepalHour
-        )}:${toNepaliDigits(nepalMinute)}:${toNepaliDigits(nepalSecond)}`;
+    const parseAPIDateString = (dateString) => {
+      // Split the date string into components
+      const [datePart, timePart] = dateString.split(" ");
+      const [year, month, day] = datePart.split("-").map(Number);
+      const [hour, minute, second] = timePart.split(":").map(Number);
 
-        const dateInput = document.getElementById("rawDateTime");
-        const dateInputMessage = document.getElementById("rawDateTimeMessage");
+      // Nepali Offset
+      const nepaliOffset = 5 * 60 * 60 * 1000 + 45 * 60 * 1000; // 5h45m in milliseconds
+      const utcTime = Date.UTC(year, month - 1, day, hour, minute, second) - nepaliOffset;
+      return new Date(utcTime);
+    };
 
-        dateInput.value = `${bsYear}-${padNumberWithZeroToMakeTwoDigits(
-          bsMonth
-        )}-${padNumberWithZeroToMakeTwoDigits(bsDate)}`;
-        dateInput.title = "Click to copy";
-        dateInput.style.fontWeight = "normal";
+    const updateDateTime = () => {
+      const now = serverTime
+        ? new Date(serverTime.getTime() + (Date.now() - startTime))
+        : new Date();
 
-        dateInput.addEventListener("click", () => {
-          navigator.clipboard.writeText(dateInput.value);
-          dateInput.style.fontWeight = "bold";
-          dateInputMessage.textContent = "Copied to clipboard";
-          setTimeout(() => {
-            dateInput.style.fontWeight = "normal";
-            dateInputMessage.textContent = "Click to copy";
-          }, 1000);
-        });
-
-        // Update English date
-        document.getElementById("englishDate").textContent =
-          `${nepalYear}-${nepalMonth.toString().padStart(2, "0")}-${nepalDay
-            .toString()
-            .padStart(2, "0")} ` + `${nepalHour}:${nepalMinute}:${nepalSecond}`;
-
-        // Update copy field
-        document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth
-          .toString()
-          .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
-      };
-
-      let startTime;
-      document.addEventListener("DOMContentLoaded", async () => {
-        updateDateTime();
-        await fetchServerTime();
-        startTime = Date.now();
-        updateDateTime();
-        setInterval(updateDateTime, 1000);
+      // Get Nepal's date/time components
+      const nepalFormatter = new Intl.DateTimeFormat("en-US", {
+        timeZone: "Asia/Kathmandu",
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+        weekday: "long",
+        hour12: false,
       });
-    </script>
-  </body>
+
+      const parts = nepalFormatter.formatToParts(now);
+      const getPart = (type) => parts.find((p) => p.type === type)?.value;
+
+      // Extract Nepal time components
+      const nepalYear = parseInt(getPart("year"));
+      const nepalMonth = parseInt(getPart("month"));
+      const nepalDay = parseInt(getPart("day"));
+      const nepalWeekday = getPart("weekday");
+      const nepalHour = getPart("hour").padStart(2, "0");
+      const nepalMinute = getPart("minute").padStart(2, "0");
+      const nepalSecond = getPart("second").padStart(2, "0");
+
+      // Convert to BS date
+      const { bsYear, bsMonth, bsDate } = convertADtoBS(
+        nepalYear,
+        nepalMonth,
+        nepalDay
+      );
+
+      // Get correct Nepali weekday index
+      const weekdayMap = {
+        Sunday: 0,
+        Monday: 1,
+        Tuesday: 2,
+        Wednesday: 3,
+        Thursday: 4,
+        Friday: 5,
+        Saturday: 6,
+      };
+      const weekDayIndex = weekdayMap[nepalWeekday];
+
+      // Update display elements
+      document.getElementById("nepaliDay").textContent =
+        nepaliWeekdays[weekDayIndex];
+      document.getElementById("nepaliDate").textContent = `${toNepaliDigits(
+        bsDate
+      )} ${bsMonths[bsMonth - 1]} ${toNepaliDigits(bsYear)}`;
+      document.getElementById("nepaliTime").textContent = `${toNepaliDigits(
+        nepalHour
+      )}:${toNepaliDigits(nepalMinute)}:${toNepaliDigits(nepalSecond)}`;
+
+      const dateInput = document.getElementById("rawDateTime");
+      const dateInputMessage = document.getElementById("rawDateTimeMessage");
+
+      dateInput.value = `${bsYear}-${padNumberWithZeroToMakeTwoDigits(
+        bsMonth
+      )}-${padNumberWithZeroToMakeTwoDigits(bsDate)}`;
+      dateInput.title = "Click to copy";
+      dateInput.style.fontWeight = "normal";
+
+      dateInput.addEventListener("click", () => {
+        navigator.clipboard.writeText(dateInput.value);
+        dateInput.style.fontWeight = "bold";
+        dateInputMessage.textContent = "Copied to clipboard";
+        setTimeout(() => {
+          dateInput.style.fontWeight = "normal";
+          dateInputMessage.textContent = "Click to copy";
+        }, 1000);
+      });
+
+      // Update English date
+      document.getElementById("englishDate").textContent =
+        `${nepalYear}-${nepalMonth.toString().padStart(2, "0")}-${nepalDay
+          .toString()
+          .padStart(2, "0")} ` + `${nepalHour}:${nepalMinute}:${nepalSecond}`;
+
+      // Update copy field
+      document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth
+        .toString()
+        .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
+    };
+
+    let startTime;
+    document.addEventListener("DOMContentLoaded", async () => {
+      updateDateTime();
+      await fetchServerTime();
+      startTime = Date.now();
+      updateDateTime();
+      setInterval(updateDateTime, 1000);
+    });
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
 (Closes #13 )
# Improve English Date Format Display

Changed the English date format to be more human-readable using the British/UK style (DMY format).

## Changes
- Added array of English month names
- Converted 24-hour time format to 12-hour format with AM/PM
- Updated date display from `YYYY-MM-DD HH:mm:ss` to a more readable format like `28 January 2021 12:52PM`

## Before
```2024-01-28 12:52:30```

## After
```28 January 2024 12:52PM```
