### PR TITLE
Improve English Date Display Format

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -567,16 +567,23 @@
           }, 1000);
         });
 
-        // Update English date
-        document.getElementById("englishDate").textContent =
-          `${nepalYear}-${nepalMonth.toString().padStart(2, "0")}-${nepalDay
-            .toString()
-            .padStart(2, "0")} ` + `${nepalHour}:${nepalMinute}:${nepalSecond}`;
+      // Update English date
+      const englishMonths = [
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December'
+      ];
+
+       // Convert 24-hour format to 12-hour format with AM/PM
+      const hour12 = nepalHour % 12 || 12;
+      const ampm = nepalHour >= 12 ? 'PM' : 'AM';
+
+      document.getElementById("englishDate").textContent =
+        `${nepalDay} ${englishMonths[nepalMonth - 1]} ${nepalYear} ${hour12}:${nepalMinute} ${ampm}`;
 
         // Update copy field
-        document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth
-          .toString()
-          .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
+      document.getElementById("rawDateTime").value = `${bsYear}-${bsMonth
+        .toString()
+        .padStart(2, "0")}-${bsDate.toString().padStart(2, "0")}`;
       };
 
       let startTime;


### PR DESCRIPTION
 (Closes #13 )
# Improve English Date Display Format

Changed the English date format to be more human-readable using the British/UK style (DMY format).

## Changes
- Added array of English month names
- Converted 24-hour time format to 12-hour format with AM/PM
- Updated date display from `YYYY-MM-DD HH:mm:ss` to a more readable format like `28 January 2024 12:52 PM`

## Before
```2024-01-28 12:52:30```

## After
```28 January 2024 12:52 PM```
